### PR TITLE
Update partOf formatting to follow the pattern of whereabouts and oth…

### DIFF
--- a/Groups/Sembaran Army/Army Garrison of Cleenseau.md
+++ b/Groups/Sembaran Army/Army Garrison of Cleenseau.md
@@ -1,6 +1,6 @@
 ---
 headerVersion: 2023.11.25
-tags: [organization]
+tags: [organization, testcase]
 displayDefaults: {partOf: '<typeof:A> of <partof>', boxInfo: ''}
 name: Army Garrison of Cleenseau
 partOf: Dunfry Regiment
@@ -11,6 +11,7 @@ whereabouts:
 ---
 # The Army Garrison of Cleenseau
 >[!info]+ Information
+> `$=dv.view("_scripts/view/get_Affiliations")`
 > a garrison of the [[Dunfry Regiment]], the [[Army of the West]], the [[Sembaran Army]], [[Sembara]]
 >> `$=dv.view("_scripts/view/get_Whereabouts")`
 

--- a/People/Historical Figures/Sembaran Royalty/Arryn III.md
+++ b/People/Historical Figures/Sembaran Royalty/Arryn III.md
@@ -1,6 +1,6 @@
 ---
 headerVersion: 2023.11.25
-tags: [person/ruler, status/unknown]
+tags: [person/ruler, status/unknown, testcase]
 campaignInfo: []
 name: Arryn III
 born: 1702
@@ -9,8 +9,8 @@ ancestry: Sembaran
 gender: male
 reignStart: 1745
 leaderOf:
-- {place: Sembara}
-- {place: Tyrwingha}
+- {place: Sembara, start: 1745}
+- {place: Tyrwingha, start: 1745}
 affiliations: [{org: House of Lils, type: primary}]
 ---
 # Arryn III

--- a/People/Historical Figures/Sembaran Royalty/Blanche II.md
+++ b/People/Historical Figures/Sembaran Royalty/Blanche II.md
@@ -1,5 +1,5 @@
 ---
-headerVersion: 2023.11.20
+headerVersion: 2023.11.25
 tags: [historical, person/ruler, person, dufr/unaware, status/unknown]
 displayDefaults: {startStatus: born, startPrefix: b., endPrefix: d., endStatus: died}
 campaignInfo: []
@@ -18,9 +18,9 @@ affiliations: [House of Sewick]
 ---
 # Queen Blanche II
 >[!info]+ Biographical Info
-> [[Sembara|Sembaran]] [[Humans|human]], she/her of the [[House of Sewick]]
+> A [[Sembara|Sembaran]] [[Humans|human]] (she/her)
 > `$=dv.view("_scripts/view/get_PageDatedValue")`
-> `$=dv.view("_scripts/view/get_RegnalValue")`
+> `$=dv.view("_scripts/view/get_Affiliations")`
 
 The second child of [[Elaine I]] and [[Cynan]]. Her son, [[Arryn II]], succeeds her to the united crowns.
 

--- a/People/Historical Figures/Sembaran Royalty/Derik III.md
+++ b/People/Historical Figures/Sembaran Royalty/Derik III.md
@@ -1,6 +1,6 @@
 ---
 headerVersion: 2023.11.25
-tags: [historical, person/ruler, status/needswork/notes]
+tags: [historical, person/ruler, status/needswork/notes, testcase]
 name: Derik III
 born: 1484
 species: human

--- a/People/Historical Figures/Sembaran Royalty/Elaine I.md
+++ b/People/Historical Figures/Sembaran Royalty/Elaine I.md
@@ -1,6 +1,6 @@
 ---
 headerVersion: 2023.11.25
-tags: [historical, person/ruler, status/needswork/notes]
+tags: [historical, person/ruler, status/needswork/notes, testcase]
 name: Elaine I
 born: 1539
 species: human

--- a/People/Historical Figures/Sembaran Royalty/Elaine II.md
+++ b/People/Historical Figures/Sembaran Royalty/Elaine II.md
@@ -1,4 +1,5 @@
 ---
+headerVersion: 2023.11.25
 tags: [historical, person, dufr/unaware, person/ruler, status/unknown]
 displayDefaults: {startStatus: born, startPrefix: b., endPrefix: d., endStatus: died}
 campaignInfo: []
@@ -12,13 +13,13 @@ title: Queen
 leaderOf:
 - {place: Tyrwingha, start: 1713-09-12}
 - {place: Sembara, start: 1720-06-15}
-affiliations: [House of Lils]
+affiliations: [{org: House of Lils, type: primary}]
 ---
-# Elaine II
->[!info]+ Biographical Summary
->[[Humans|human]]  ([[Sembara|Sembaran]]), she/her of [[House of Lils]]
->`$=dv.view("_scripts/view/get_PageDatedValue")`
->`$=dv.view("_scripts/view/get_RegnalValue")`
+# Queen Elaine II
+>[!info]+ Biographical Info
+> A [[Sembara|Sembaran]] [[Humans|human]] (she/her), of the [[House of Lils]]
+> `$=dv.view("_scripts/view/get_PageDatedValue")`
+> `$=dv.view("_scripts/view/get_Affiliations")`
 
 The first monarch of the [[House of Lils]], descended from, Derik, the youngest son of [[Elaine I]], and [[Morgaine]], a Tyrwinghan [[Oracle of the Riven|oracle]].
 

--- a/People/Historical Figures/Sembaran Royalty/Robert I.md
+++ b/People/Historical Figures/Sembaran Royalty/Robert I.md
@@ -12,11 +12,11 @@ died: 1720-06-15
 leaderOf:
 - {place: Sembara}
 title: King
-affiliations: [House of Sewick]
+affiliations: [{org: House of Sewick, type: primary}]
 ---
 # King Robert I
 >[!info]+ Biographical Info
-> A [[Sembara|Sembaran]] [[Humans|human]] (he/him)
+> A [[Sembara|Sembaran]] [[Humans|human]] (he/him), of the [[House of Sewick]]
 > `$=dv.view("_scripts/view/get_PageDatedValue")`
 > `$=dv.view("_scripts/view/get_Affiliations")`
 

--- a/People/Historical Figures/Sembaran Royalty/Wisym I.md
+++ b/People/Historical Figures/Sembaran Royalty/Wisym I.md
@@ -1,5 +1,5 @@
 ---
-headerVersion: 2023.11.20
+headerVersion: 2023.11.25
 tags: [historical, person, dufr/unaware, person/ruler, status/unknown]
 campaignInfo: []
 name: Wisym I
@@ -10,14 +10,14 @@ gender: male
 reignStart: 1568
 title: King
 died: 1582
-affiliations: [House of Sewick]
+affiliations: [{org: House of Sewick, type: primary}]
 leaderOf:
 - {place: Sembara}
 ---
 # King Wisym I
 >[!info]+ Biographical Info
-> [[Sembara|Sembaran]] [[Humans|human]], he/him of the [[House of Sewick]]
+> A [[Sembara|Sembaran]] [[Humans|human]] (he/him), of the [[House of Sewick]]
 > `$=dv.view("_scripts/view/get_PageDatedValue")`
-> `$=dv.view("_scripts/view/get_RegnalValue")`
+> `$=dv.view("_scripts/view/get_Affiliations")`
 
 The eldest son of [[Eloise|Eloise]], he ruled Sembara after the [[Interregum of 1568]]. He was a mostly ineffectual king and was partly selected as a compromise king because as a gay man he had never had children with his husband and thus had no immediate heir.

--- a/Things/Artifacts of Power/Cloak of Rainbows.md
+++ b/Things/Artifacts of Power/Cloak of Rainbows.md
@@ -3,6 +3,7 @@ headerVersion: 2023.11.25
 tags: [item/magical, testcase, status/needswork/collate, status/needswork/notes, status/needswork/wip]
 campaignInfo:
 created: 917
+subTypeOf: magical
 name: Cloak of Rainbows
 aliases: [Cloak of Rainbows, Mantle of Protection]
 typeOf: cloak
@@ -16,6 +17,7 @@ whereabouts:
 >[!info]+ Information
 > (unique magical cloak)
 > `$=dv.view("_scripts/view/get_PageDatedValue")`
+> `$=dv.view("_scripts/view/get_Affiliations")`
 >> `$=dv.view("_scripts/view/get_Whereabouts")`
 
 %% whereabouts needs work%%


### PR DESCRIPTION
This introduces proper support for part of chains. A partOf chain, for now, is defined as a set of pages linked via partOf that are all of the same type. The chain (for now) just returns the name of each element in the chain, although in the future it could return the entire page metadata to allow for more complexity (i.e. format strings, link text, etc)

TokenParser is then updated to support using the part of chain, plus the partof-list formatter, to format the list. This is similar to have whereabouts and affiliations work.

Secondarily, the common code for formatting a list is abstracted into a generic format list function, and the different list formatters all call it.